### PR TITLE
player now slides on collision

### DIFF
--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -1,4 +1,4 @@
-extends PhysicsBody2D
+extends CharacterBody2D
 
 class_name Player
 #the resource that will be used to make an inventory (player_inventory.tres)
@@ -13,7 +13,6 @@ const MAX_COINS = pow(2, 62)
 
 var coins : int = 500 # replace value with db call once implemented
 var chips : int = 10 # replace value with db call once implemented
-var velocity : Vector2
 var is_dashing : bool = false
 
 @onready var animated_sprite : AnimatedSprite2D = $AnimatedSprite2D
@@ -86,7 +85,7 @@ func _input(event: InputEvent) -> void:
 
 func _physics_process(delta : float)->void:
 	move(current_state, delta)
-	move_and_collide(velocity)
+	move_and_slide()
 	
 func move(curr_state : movement_state, delta : float) -> void:
 	match curr_state:
@@ -100,7 +99,7 @@ func move(curr_state : movement_state, delta : float) -> void:
 			animated_sprite.speed_scale = DASH_MULT
 
 # Updated function for 8 directional movement
-func get_movement_input(delta : float) -> void:
+func get_movement_input(_delta : float) -> void:
 	velocity = Vector2.ZERO
 	
 	var x_dir : float = Input.get_axis("move_left", "move_right")
@@ -108,7 +107,7 @@ func get_movement_input(delta : float) -> void:
 	velocity = Vector2(x_dir, y_dir)
 	
 	if velocity != Vector2.ZERO:
-		velocity = velocity.normalized() * SPEED * delta
+		velocity = velocity.normalized() * SPEED
 		
 		# Determine direction name for animation
 		# Appends direction based on directional input

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=49 format=3 uid="uid://b0flhrlw7t57t"]
 
 [ext_resource type="Script" uid="uid://c2lajecmvs0ct" path="res://scenes/player/player.gd" id="1_onrkg"]
-[ext_resource type="Resource" uid="uid://4jsm7xxboko" path="res://scenes/player/player_inv.tres" id="2_qhqgy"]
+[ext_resource type="Resource" uid="uid://c7iya0quitj4s" path="res://scenes/player/player_inv.tres" id="2_qhqgy"]
 [ext_resource type="PackedScene" uid="uid://bk1hol15q64bh" path="res://scenes/inventory/inv_ui.tscn" id="4_dqkch"]
 [ext_resource type="Texture2D" uid="uid://mgupfasihl7i" path="res://assets/char_sprites/Chay Walk Cycle-Sheet.png" id="4_qlg0r"]
 [ext_resource type="Texture2D" uid="uid://bl24jrao46dmm" path="res://assets/char_sprites/Chay Idle-Sheet.png" id="4_tuyoq"]


### PR DESCRIPTION
Changed player script from inheriting physicsbody to characterbody. unsure why it was physics body to begin with if the default is characterbody. Then adjusted move_and_collide() to move_and_slide() with the appropriate modifications for velocity calculations. 