### PR TITLE
swapping and exiting no longer deletes the item

### DIFF
--- a/scenes/inventory/inv_ui_slot.gd
+++ b/scenes/inventory/inv_ui_slot.gd
@@ -26,7 +26,7 @@ func insert(i_stack: ItemStackUI) -> void:
 	
 	if !item_stack.invSlot or inv.slots[index] == item_stack.invSlot:
 		return
-	inv.insert_on_cursor(index, i_stack.invSlot)
+	inv.insert_slot_at(index, i_stack.invSlot)
 	inv.update.emit()
 
 ## Signifies this slot is selected by turning on the selected border

--- a/scenes/inventory/inventory.gd
+++ b/scenes/inventory/inventory.gd
@@ -90,7 +90,7 @@ func deselect()->void:
 ## Used specifically when moving items with the mouse. 
 ## Ensures that if an item is clicked but not dropped, 
 ## it will remain in the correct slot even when exiting the scene.
-func insert_on_cursor(idx: int, invSlot: InvSlot)->void:
+func insert_slot_at(idx: int, invSlot: InvSlot)->void:
 	var old_owner: Inv = invSlot.owner
 	var old_idx: int = invSlot.index
 	
@@ -100,12 +100,10 @@ func insert_on_cursor(idx: int, invSlot: InvSlot)->void:
 		empty_slot.owner = old_owner
 		empty_slot.index = old_idx
 		old_owner.slots[old_idx] = empty_slot
-		old_owner.update.emit()
 	
 	invSlot.owner = self
 	invSlot.index = idx
 	slots[idx] = invSlot
-	update.emit()
 	
 ## Creates and returns a dictionary representation of this inventory. [br][br]
 ##

--- a/scenes/shelf/shelf.gd
+++ b/scenes/shelf/shelf.gd
@@ -78,18 +78,18 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		if shelf_ui.visible:
 			close_shelf()
+			get_viewport().set_input_as_handled()
 
 func close_shelf()->void:
 	var player:Player = get_tree().get_first_node_in_group("player")
-	player_inv = player.get_inventory()
 	if player:
+		player_inv = player.get_inventory()
 		inv.lock = false
 		clear_queue()
 		player.open_inv_ui()
 		shelf_ui.visible = false
 		# sync inventories to ui on close
 		player_inv.update.emit()
-		get_viewport().set_input_as_handled()
 		# update visual on close
 		update_visuals()
 
@@ -151,6 +151,7 @@ func _debug_set_shelf_inv()->void:
 	green.sellable = 1
 	for i in range(5):
 		inv.insert(green)
+	inv.insert(ItemRegistry.new_item("item_red_potion"))
 
 # handles NPC entering the interact area.
 # when there is a lock, the npc goes into a waiting queue

--- a/scenes/shelf/shelf_inv_ui.gd
+++ b/scenes/shelf/shelf_inv_ui.gd
@@ -141,6 +141,12 @@ func insert_to_slot(slot:Button)->void:
 ## the given [param slot].
 func swap_items(slot:Button)->void:
 	var tempItem: ItemStackUI = slot.pick_item()
+	
+	## In the old inv, at the old slot, put the swapped item (backend only)
+	var origin_inv: Inv = item_on_cursor.invSlot.owner	## The former inv
+	var origin_idx: int = item_on_cursor.invSlot.index	## Where the old item was
+	origin_inv.insert_slot_at(origin_idx, tempItem.invSlot)
+	
 	insert_to_slot(slot)
 	
 	item_on_cursor = tempItem

--- a/scenes/shelf/shelf_inv_ui_slot.gd
+++ b/scenes/shelf/shelf_inv_ui_slot.gd
@@ -21,7 +21,7 @@ func insert(i_stack: ItemStackUI) -> void:
 	if !item_stack.invSlot or inv.slots[index] == item_stack.invSlot:
 		return
 	#item_stack.update_slot()
-	inv.insert_on_cursor(index, i_stack.invSlot)
+	inv.insert_slot_at(index, i_stack.invSlot)
 
 ## Removes the item from this slot and returns it.
 func pick_item()->ItemStackUI:


### PR DESCRIPTION
Fixed the bug we had when swapping items and then leaving the shelf UI. Previously, the item that stayed in the cursor after swapping would be deleted. This is now fixed and will return to the the slot that was previously occupied by the last unplaced swapped item. In other words, the first slot clicked. This is because that is the only slot guaranteed to be empty (since the item was originally taken from that slot). 